### PR TITLE
Correctly implement `atom?` predicate for cljs

### DIFF
--- a/src/onyx/spec.cljc
+++ b/src/onyx/spec.cljc
@@ -4,7 +4,9 @@
                :cljs [cljs.spec.alpha :as s :refer-macros [coll-of]])))
 
 (defn atom? [x]
-  (instance? clojure.lang.Atom x))
+  (instance? #?(:clj clojure.lang.IAtom
+                :cljs Atom) x))
+
 
 (defn namespaced-keyword? [x]
   (and (keyword? x) (namespace x)))


### PR DESCRIPTION
Resolves:
```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: onyx/spec.cljc:7:14
--------------------------------------------------------------------------------
   4 |                :cljs [cljs.spec.alpha :as s :refer-macros [coll-of]])))
   5 |
   6 | (defn atom? [x]
   7 |   (instance? clojure.lang.Atom x))
--------------------^-----------------------------------------------------------
 Use of undeclared Var onyx.spec/clojure
--------------------------------------------------------------------------------
   8 |
   9 | (defn namespaced-keyword? [x]
  10 |   (and (keyword? x) (namespace x)))
  11 |
--------------------------------------------------------------------------------
```